### PR TITLE
Fixing Kafka vulnerabilities

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotest = "6.0.0.M1"
-kafka = "3.9.0"
+kafka = "3.9.1"
 kotlin = "2.1.0"
 kotlinx-coroutines = "1.10.1"
 dokka = "2.0.0"


### PR DESCRIPTION
Updating the Kafka version to v3.9.1 are fixing CVE issues we have in production:

- CVE-2025-27817
- CVE-2025-27819
- CVE-2025-27818

Also for some reason this points to `org.apache.kafka:kafka-clients@3.8.1`. But in your config it says `3.9.0`. Can you look into this?

Could you fix a patch for us with these changes?