### PR TITLE
Remove no longer used `projects.group` property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,5 @@
 kotlin.code.style=official
 
-# Package definitions
-projects.group=io.github.nomisrev
-
 SONATYPE_HOST=S01
 RELEASE_SIGNING_ENABLED=true
 


### PR DESCRIPTION
Not in use since af6d6af25799ea6715b47db08a099c9ebf7ee81c