### PR TITLE
Add createConsumer hook to ReceiverSettings

### DIFF
--- a/src/main/kotlin/io/github/nomisRev/kafka/receiver/KafkaReceiver.kt
+++ b/src/main/kotlin/io/github/nomisRev/kafka/receiver/KafkaReceiver.kt
@@ -3,6 +3,7 @@ package io.github.nomisRev.kafka.receiver
 import io.github.nomisRev.kafka.receiver.internals.EventLoop
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
+import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.slf4j.Logger
@@ -83,14 +84,14 @@ private class DefaultKafkaReceiver<K, V>(private val settings: ReceiverSettings<
   @OptIn(ExperimentalCoroutinesApi::class)
   private fun <A> consumer(
     groupId: String,
-    block: suspend (CoroutineScope, KafkaConsumer<K, V>) -> Flow<A>
+    block: suspend (CoroutineScope, Consumer<K, V>) -> Flow<A>
   ): Flow<A> = flow {
     kafkaConsumerDispatcher(groupId).use { dispatcher: ExecutorCoroutineDispatcher ->
       val job = Job()
       val scope = CoroutineScope(job + dispatcher + defaultCoroutineExceptionHandler)
       try {
         withContext(dispatcher) {
-          KafkaConsumer(settings.toProperties(), settings.keyDeserializer, settings.valueDeserializer)
+          settings.createConsumer(settings)
         }.use { emit(block(scope, it)) }
       } finally {
         job.cancelAndJoin()

--- a/src/main/kotlin/io/github/nomisRev/kafka/receiver/ReceiverSettings.kt
+++ b/src/main/kotlin/io/github/nomisRev/kafka/receiver/ReceiverSettings.kt
@@ -1,7 +1,9 @@
 package io.github.nomisRev.kafka.receiver
 
 import io.github.nomisRev.kafka.NothingDeserializer
+import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.serialization.Deserializer
 import java.util.Properties
 import kotlin.time.Duration
@@ -21,6 +23,10 @@ private val DEFAULT_COMMIT_INTERVAL = 5.seconds
  * It forces to specify the required parameters to offer a type-safe API,
  * so it requires [bootstrapServers], [valueDeserializer], and [groupId].
  * All other parameters are configured to the sanest defaults.
+ *
+ * @param createConsumer the way the underlying [Consumer] is created for [KafkaReceiver.receive]
+ *   and [KafkaReceiver.receiveAutoAck]. Overriding it allows decorating the consumer, e.g. to
+ *   customise its pause/resume behaviour, analogous to [io.github.nomisRev.kafka.publisher.PublisherSettings.createProducer].
  */
 public data class ReceiverSettings<K, V>(
   val bootstrapServers: String,
@@ -35,6 +41,8 @@ public data class ReceiverSettings<K, V>(
   val maxDeferredCommits: Int = 0,
   val closeTimeout: Duration = Duration.INFINITE,
   val properties: Properties = Properties(),
+  val createConsumer: suspend (ReceiverSettings<K, V>) -> Consumer<K, V> =
+    { settings -> KafkaConsumer(settings.toProperties(), settings.keyDeserializer, settings.valueDeserializer) },
 ) {
   init {
     require(commitRetryInterval.isPosNonZero()) { "Commit Retry interval must be >= 0 but found $pollTimeout" }
@@ -68,6 +76,8 @@ public fun <V> ReceiverSettings(
   maxDeferredCommits: Int = 0,
   closeTimeout: Duration = Long.MAX_VALUE.nanoseconds,
   properties: Properties = Properties(),
+  createConsumer: suspend (ReceiverSettings<Nothing, V>) -> Consumer<Nothing, V> =
+    { settings -> KafkaConsumer(settings.toProperties(), settings.keyDeserializer, settings.valueDeserializer) },
 ): ReceiverSettings<Nothing, V> =
   ReceiverSettings(
     bootstrapServers,
@@ -81,5 +91,6 @@ public fun <V> ReceiverSettings(
     maxCommitAttempts,
     maxDeferredCommits,
     closeTimeout,
-    properties
+    properties,
+    createConsumer
   )

--- a/src/main/kotlin/io/github/nomisRev/kafka/receiver/ReceiverSettings.kt
+++ b/src/main/kotlin/io/github/nomisRev/kafka/receiver/ReceiverSettings.kt
@@ -27,6 +27,8 @@ private val DEFAULT_COMMIT_INTERVAL = 5.seconds
  * @param createConsumer the way the underlying [Consumer] is created for [KafkaReceiver.receive]
  *   and [KafkaReceiver.receiveAutoAck]. Overriding it allows decorating the consumer, e.g. to
  *   customise its pause/resume behaviour, analogous to [io.github.nomisRev.kafka.publisher.PublisherSettings.createProducer].
+ *   [KafkaReceiver.withConsumer] does not go through it: it hands out a [KafkaConsumer] rather than
+ *   a [Consumer], so it cannot accept an arbitrary decoration without a breaking signature change.
  */
 public data class ReceiverSettings<K, V>(
   val bootstrapServers: String,
@@ -80,17 +82,17 @@ public fun <V> ReceiverSettings(
     { settings -> KafkaConsumer(settings.toProperties(), settings.keyDeserializer, settings.valueDeserializer) },
 ): ReceiverSettings<Nothing, V> =
   ReceiverSettings(
-    bootstrapServers,
-    NothingDeserializer,
-    valueDeserializer,
-    groupId,
-    autoOffsetReset,
-    commitStrategy,
-    pollTimeout,
-    commitRetryInterval,
-    maxCommitAttempts,
-    maxDeferredCommits,
-    closeTimeout,
-    properties,
-    createConsumer
+    bootstrapServers = bootstrapServers,
+    keyDeserializer = NothingDeserializer,
+    valueDeserializer = valueDeserializer,
+    groupId = groupId,
+    autoOffsetReset = autoOffsetReset,
+    commitStrategy = commitStrategy,
+    pollTimeout = pollTimeout,
+    commitRetryInterval = commitRetryInterval,
+    maxCommitAttempts = maxCommitAttempts,
+    maxDeferredCommits = maxDeferredCommits,
+    closeTimeout = closeTimeout,
+    properties = properties,
+    createConsumer = createConsumer,
   )

--- a/src/test/kotlin/io/github/nomisrev/kafka/receiver/KafkaReceiverSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/kafka/receiver/KafkaReceiverSpec.kt
@@ -23,10 +23,15 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.flow.toSet
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
+import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 data class KeyValue(val key: String, val value: String)
 
@@ -71,6 +76,34 @@ class KafkaReceiverSpec : KafkaSpec() {
         .toSet(),
       produced.toSet()
     )
+  }
+
+  @Test
+  fun `A custom createConsumer is used for receiving`() = withTopic {
+    val messageCount = 10
+    publishToKafka(topic, produced(0, messageCount))
+    val pollCount = AtomicInteger(0)
+    val base = receiverSetting()
+    val settings = base.copy(
+      createConsumer = { s ->
+        val delegate = base.createConsumer(s)
+        object : Consumer<String, String> by delegate {
+          override fun poll(timeout: Duration): ConsumerRecords<String, String> =
+            delegate.poll(timeout).also { pollCount.incrementAndGet() }
+        }
+      }
+    )
+    assertEquals(
+      KafkaReceiver(settings)
+        .receive(topic.name())
+        .map { record ->
+          KeyValue(record.key(), record.value())
+            .also { record.offset.acknowledge() }
+        }.take(messageCount)
+        .toSet(),
+      produced(0, messageCount).toSet()
+    )
+    assertTrue(pollCount.get() > 0, "Expected the decorated consumer to be polled")
   }
 
   @Test

--- a/src/test/kotlin/io/github/nomisrev/kafka/receiver/KafkaReceiverSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/kafka/receiver/KafkaReceiverSpec.kt
@@ -107,6 +107,33 @@ class KafkaReceiverSpec : KafkaSpec() {
   }
 
   @Test
+  fun `A custom createConsumer is used for receiving with auto-ack`() = withTopic {
+    val messageCount = 10
+    publishToKafka(topic, produced(0, messageCount))
+    val pollCount = AtomicInteger(0)
+    val base = receiverSetting()
+    val settings = base.copy(
+      createConsumer = { s ->
+        val delegate = base.createConsumer(s)
+        object : Consumer<String, String> by delegate {
+          override fun poll(timeout: Duration): ConsumerRecords<String, String> =
+            delegate.poll(timeout).also { pollCount.incrementAndGet() }
+        }
+      }
+    )
+    assertEquals(
+      KafkaReceiver(settings)
+        .receiveAutoAck(topic.name())
+        .flattenConcat()
+        .map { record -> KeyValue(record.key(), record.value()) }
+        .take(messageCount)
+        .toSet(),
+      produced(0, messageCount).toSet()
+    )
+    assertTrue(pollCount.get() > 0, "Expected the decorated consumer to be polled")
+  }
+
+  @Test
   fun `Continuous receiving does not overflow stack`() = withTopic {
     val largeCount = 20_000 // when it _was_ overflowing stack, it only took ~4095 messages.
     publishScope {

--- a/src/test/kotlin/io/github/nomisrev/kafka/receiver/ReceiverSettingsSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/kafka/receiver/ReceiverSettingsSpec.kt
@@ -1,0 +1,34 @@
+package io.github.nomisrev.kafka.receiver
+
+import io.github.nomisRev.kafka.receiver.ReceiverSettings
+import java.util.Properties
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlinx.coroutines.runBlocking
+import org.apache.kafka.clients.consumer.MockConsumer
+import org.apache.kafka.clients.consumer.OffsetResetStrategy
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.junit.jupiter.api.Test
+
+class ReceiverSettingsSpec {
+
+  @Test
+  fun `the keyless ReceiverSettings hands its createConsumer on`() = runBlocking {
+    val consumer = MockConsumer<Nothing, String>(OffsetResetStrategy.EARLIEST)
+    val properties = Properties().apply { put("client.id", "keyless-forwarding") }
+
+    val settings = ReceiverSettings(
+      bootstrapServers = "unused:9092",
+      valueDeserializer = StringDeserializer(),
+      groupId = "keyless-group",
+      properties = properties,
+      createConsumer = { consumer },
+    )
+
+    assertSame(consumer, settings.createConsumer(settings))
+    /* The two parameters next to createConsumer, so that this also fails if the overload ever
+     * stops handing its arguments on by name. */
+    assertEquals(properties, settings.properties)
+    assertEquals("keyless-group", settings.groupId)
+  }
+}


### PR DESCRIPTION
## Motivation

`PublisherSettings` already allows customising how the underlying `Producer` is created via
`createProducer`. This PR adds the symmetric hook to `ReceiverSettings`:

```kotlin
val createConsumer: suspend (ReceiverSettings<K, V>) -> Consumer<K, V> =
  { settings -> KafkaConsumer(settings.toProperties(), settings.keyDeserializer, settings.valueDeserializer) }
```

The main use case is decorating the consumer, e.g. to customise pause/resume behaviour.

Our concrete case: the stock `KafkaConsumer` sticks to one partition until it is drained when
partitions have significant backlog (consecutive `poll()`s return records of a single partition,
as long as the lag per partition exceeds the fetch batch size). When records are processed
concurrently per partition, this serialises the whole pipeline while catching up. We measured a
50k-message backlog over 6 partitions with a 1ms-per-record handler processed in per-partition
concurrent flows:

- stock consumer: 58.5s (partitions consumed strictly one after another)
- with a decorating consumer that pauses a partition whenever a poll returned records of only
  that partition: 11.8s (partitions interleaved in max.poll.records-sized chunks)

With reactor-kafka this decoration was possible via a custom `ConsumerFactory`; kotlin-kafka
currently offers no equivalent seam.

## Changes

- `ReceiverSettings` gains a `createConsumer` parameter (last position, defaulted — binary and
  source compatible for positional and named usage), mirroring `PublisherSettings.createProducer`.
- The keyless `ReceiverSettings(...)` convenience function passes it through, like the
  `PublisherSettings` counterpart does for `createProducer`.
- `DefaultKafkaReceiver` creates consumers for `receive`/`receiveAutoAck` through the hook; the
  internal plumbing is widened from `KafkaConsumer` to the `Consumer` interface (the `EventLoop`
  already takes `Consumer`). `withConsumer` is unchanged, since its public signature exposes
  `KafkaConsumer`.
- Test: `A custom createConsumer is used for receiving` verifies a decorated consumer is polled
  and records flow through it.

Decorators can delegate to the default like this:

```kotlin
val base = ReceiverSettings(bootstrapServers, keyDeserializer, valueDeserializer, groupId)
val settings = base.copy(
  createConsumer = { s -> MyBalancingConsumer(base.createConsumer(s)) }
)
```
