### PR TITLE
Retry offset commits that race a consumer-group rebalance

### DIFF
--- a/src/main/kotlin/io/github/nomisRev/kafka/receiver/internals/EventLoop.kt
+++ b/src/main/kotlin/io/github/nomisRev/kafka/receiver/internals/EventLoop.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.selects.whileSelect
 import kotlinx.coroutines.withContext
 import org.apache.kafka.clients.consumer.*
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.RebalanceInProgressException
 import org.apache.kafka.common.errors.WakeupException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -69,8 +70,7 @@ internal class EventLoop<K, V>(
   private val outerContext: CoroutineContext,
   private val awaitingTransaction: AtomicBoolean = AtomicBoolean(false),
   private val ackMode: AckMode = MANUAL_ACK,
-  private val isRetryableCommit: (Throwable) -> Boolean =
-    { e -> e is RetriableCommitFailedException },
+  private val isRetryableCommit: (Throwable) -> Boolean = ::isTransientCommitFailure,
 ) {
   private val isPolling = AtomicBoolean(true)
   private val isPaused = AtomicBoolean(false)
@@ -587,3 +587,14 @@ private fun checkConsumerThread(msg: String): Unit =
     Thread.currentThread().name.startsWith("kotlin-kafka-")
   ) { "$msg => should run on kotlin-kafka thread, but found ${Thread.currentThread().name}" }
   else Unit
+
+/**
+ * Commit failures that resolve on their own and are therefore safe to retry:
+ * - [RetriableCommitFailedException]: the broker explicitly asks for a retry,
+ * - [RebalanceInProgressException]: the commit raced a group rebalance; once the rebalance completes
+ *   the commit can simply be retried. Failing the receive flow instead turns every commit that races
+ *   a routine rebalance (scaling, deployments, member restarts) into a fatal error - reactor-kafka,
+ *   where this commit logic originates, re-enqueues these commits as well.
+ */
+internal fun isTransientCommitFailure(exception: Throwable): Boolean =
+  exception is RetriableCommitFailedException || exception is RebalanceInProgressException

--- a/src/main/kotlin/io/github/nomisRev/kafka/receiver/internals/EventLoop.kt
+++ b/src/main/kotlin/io/github/nomisRev/kafka/receiver/internals/EventLoop.kt
@@ -388,11 +388,14 @@ internal class EventLoop<K, V>(
   private fun commitFailure(commitArgs: CommittableBatch.CommitArgs, exception: Throwable) {
     checkConsumerThread("commitFailure")
     logger.warn("Commit failed", exception)
-    if (
-      !isRetryableCommit(exception) &&
-      consecutiveCommitFailures.incrementAndGet() < settings.maxCommitAttempts
-    ) {
-      logger.debug("Commit failed with exception $exception, zero retries remaining")
+    /* Counting the failure has to happen on the retryable path, otherwise [maxCommitAttempts] is
+     * never reached by the very failures it is meant to bound and they are retried forever.
+     * Mirrors ConsumerEventLoop.CommitEvent.handleFailure in reactor-kafka, where this originates. */
+    val mayRetry =
+      isRetryableCommit(exception) &&
+        consecutiveCommitFailures.incrementAndGet() < settings.maxCommitAttempts
+    if (!mayRetry) {
+      logger.debug("Cannot retry commit, it failed with $exception")
       schedulePollAfterRetrying()
       val continuations = commitArgs.continuations
       if (continuations.isNullOrEmpty()) {

--- a/src/test/kotlin/io/github/nomisrev/kafka/receiver/RebalanceRacingCommitSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/kafka/receiver/RebalanceRacingCommitSpec.kt
@@ -6,15 +6,19 @@ import io.github.nomisRev.kafka.receiver.internals.EventLoop
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.coroutines.coroutineContext
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -23,75 +27,162 @@ import org.apache.kafka.clients.consumer.MockConsumer
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.consumer.OffsetCommitCallback
 import org.apache.kafka.clients.consumer.OffsetResetStrategy
+import org.apache.kafka.clients.consumer.RetriableCommitFailedException
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.RebalanceInProgressException
+import org.apache.kafka.common.errors.TopicAuthorizationException
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.junit.jupiter.api.Test
 
+/**
+ * A commit that fails because it raced a group rebalance resolves on its own: once the rebalance
+ * completed, the commit can simply be retried. Failing the receive flow instead turns every commit
+ * that races a routine rebalance - scaling, deployments, member restarts - into a fatal error.
+ *
+ * These tests fail the *first* commit and then let every following one succeed, so they can tell
+ * apart the two answers the event loop can give: retry, or close the channel.
+ */
 class RebalanceRacingCommitSpec {
 
   @Test
   fun `a commit racing a rebalance is retried instead of failing the receive flow`() = runBlocking {
-    val topic = "commit-race-topic"
-    val partition = TopicPartition(topic, 0)
-    val commitAttempts = AtomicInteger(0)
-    val successfulCommits = CopyOnWriteArrayList<Map<TopicPartition, OffsetAndMetadata>>()
+    val consumer = failingTheFirstCommitWith(RebalanceInProgressException("commit raced the rebalance"))
+    val collecting = collect(consumer)
 
-    // the first commit races a rebalance, every following commit succeeds
-    val consumer = object : MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
-      override fun commitAsync(
-        offsets: MutableMap<TopicPartition, OffsetAndMetadata>,
-        callback: OffsetCommitCallback?,
-      ) {
-        if (commitAttempts.incrementAndGet() == 1) {
-          callback?.onComplete(offsets, RebalanceInProgressException("commit raced the rebalance"))
-        } else {
-          successfulCommits.add(offsets.toMap())
-          callback?.onComplete(offsets, null)
-        }
-      }
-    }
-    consumer.updateBeginningOffsets(mapOf(partition to 0L))
-    consumer.schedulePollTask {
-      consumer.rebalance(listOf(partition))
-      consumer.addRecord(ConsumerRecord(topic, 0, 0L, "key", "value"))
-    }
-
-    val settings = ReceiverSettings(
-      bootstrapServers = "unused:9092",
-      keyDeserializer = StringDeserializer(),
-      valueDeserializer = StringDeserializer(),
-      groupId = "commit-race-group",
-      commitStrategy = CommitStrategy.BySize(1),
-    )
-
-    // the event loop asserts that it runs on a thread named like the library's own dispatcher
-    val dispatcher = Executors.newSingleThreadExecutor { r ->
-      Thread(r, "kotlin-kafka-commit-race-group")
-    }.asCoroutineDispatcher()
-    val job = Job()
-    val scope = CoroutineScope(job + dispatcher)
     try {
-      val loop = EventLoop(setOf(topic), settings, consumer, scope, coroutineContext)
-      val firstRecord = CompletableDeferred<ConsumerRecord<String, String>>()
-      val collector = launch {
-        loop.receive().collect { records ->
-          records.forEach { record -> firstRecord.complete(record) }
-        }
-      }
-
       withTimeout(30.seconds) {
-        loop.offsetFromRecord(firstRecord.await()).acknowledge()
-        while (successfulCommits.isEmpty()) delay(50)
+        while (consumer.successfulCommits.isEmpty()) delay(20)
       }
-      collector.cancelAndJoin()
-
-      // without retrying the racing commit, the collector would have failed with
-      // RebalanceInProgressException before any successful commit could happen
-      assertEquals(1L, successfulCommits.first()[partition]?.offset())
+      assertEquals(1L, consumer.successfulCommits.first()[PARTITION]?.offset())
+      assertNull(
+        collecting.flowFailure.takeIf { it.isCompleted }?.await(),
+        "a commit that raced a rebalance must not fail the receive flow"
+      )
     } finally {
-      job.cancelAndJoin()
-      dispatcher.close()
+      collecting.close()
     }
   }
+
+  @Test
+  fun `a commit the broker asks to retry is still retried`() = runBlocking {
+    val consumer = failingTheFirstCommitWith(RetriableCommitFailedException("try again"))
+    val collecting = collect(consumer)
+
+    try {
+      withTimeout(30.seconds) {
+        while (consumer.successfulCommits.isEmpty()) delay(20)
+      }
+      assertEquals(1L, consumer.successfulCommits.first()[PARTITION]?.offset())
+      assertNull(
+        collecting.flowFailure.takeIf { it.isCompleted }?.await(),
+        "the retry the broker asked for must not fail the receive flow"
+      )
+    } finally {
+      collecting.close()
+    }
+  }
+
+  @Test
+  fun `a commit failure that will not resolve on its own still fails the receive flow`() = runBlocking {
+    val fatal = TopicAuthorizationException("not allowed to commit")
+    val consumer = failingTheFirstCommitWith(fatal)
+    val collecting = collect(consumer)
+
+    try {
+      val failure = withTimeout(30.seconds) { collecting.flowFailure.await() }
+      /* kotlinx.coroutines copies an exception when it crosses coroutines to recover its stack
+       * trace, so the collector sees an equal failure, not the very same instance. */
+      assertEquals(fatal::class, failure::class)
+      assertEquals(fatal.message, failure.message)
+      assertEquals(
+        emptyList<Map<TopicPartition, OffsetAndMetadata>>(),
+        consumer.successfulCommits.toList(),
+        "a failure that will not resolve on its own must not be retried"
+      )
+    } finally {
+      collecting.close()
+    }
+  }
+}
+
+private const val TOPIC = "commit-race-topic"
+private val PARTITION = TopicPartition(TOPIC, 0)
+
+private fun settings(): ReceiverSettings<String, String> =
+  ReceiverSettings(
+    bootstrapServers = "unused:9092",
+    keyDeserializer = StringDeserializer(),
+    valueDeserializer = StringDeserializer(),
+    groupId = "commit-race-group",
+    commitStrategy = CommitStrategy.BySize(1),
+    commitRetryInterval = 50.milliseconds,
+    closeTimeout = 5.seconds,
+  )
+
+/** Fails the first commit with [error], and lets every commit after it succeed. */
+private fun failingTheFirstCommitWith(error: Exception): CommitFailingConsumer =
+  CommitFailingConsumer(error).apply {
+    updateBeginningOffsets(mapOf(PARTITION to 0L))
+    schedulePollTask {
+      rebalance(listOf(PARTITION))
+      addRecord(ConsumerRecord(TOPIC, PARTITION.partition(), 0L, "key", "value"))
+    }
+  }
+
+private class CommitFailingConsumer(private val error: Exception) :
+  MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
+
+  private val attempts = AtomicInteger(0)
+  val successfulCommits = CopyOnWriteArrayList<Map<TopicPartition, OffsetAndMetadata>>()
+
+  override fun commitAsync(
+    offsets: MutableMap<TopicPartition, OffsetAndMetadata>,
+    callback: OffsetCommitCallback?,
+  ) {
+    requireNotNull(callback) { "the event loop always commits with a callback" }
+    if (attempts.incrementAndGet() == 1) callback.onComplete(offsets, error)
+    else {
+      successfulCommits += offsets.toMap()
+      callback.onComplete(offsets, null)
+    }
+  }
+}
+
+private class Collecting(
+  private val job: Job,
+  private val scope: CoroutineScope,
+  private val dispatcher: ExecutorCoroutineDispatcher,
+  val flowFailure: CompletableDeferred<Throwable>,
+) {
+  suspend fun close() {
+    job.cancelAndJoin()
+    scope.coroutineContext[Job]?.cancelAndJoin()
+    dispatcher.close()
+  }
+}
+
+private fun collect(consumer: MockConsumer<String, String>): Collecting {
+  /* The event loop asserts that it runs on a thread named like the library's own dispatcher. */
+  val dispatcher = Executors.newSingleThreadExecutor { runnable ->
+    Thread(runnable, "kotlin-kafka-commit-race-group")
+  }.asCoroutineDispatcher()
+  val scope = CoroutineScope(Job() + dispatcher)
+  val flowFailure = CompletableDeferred<Throwable>()
+
+  val job = scope.launch {
+    val loop = EventLoop(
+      topicNames = setOf(TOPIC),
+      settings = settings(),
+      consumer = consumer,
+      scope = scope,
+      outerContext = currentCoroutineContext(),
+    )
+    loop.receive()
+      .catch { e -> flowFailure.complete(e) }
+      .collect { records ->
+        records.forEach { record -> loop.offsetFromRecord(record).acknowledge() }
+      }
+  }
+
+  return Collecting(job, scope, dispatcher, flowFailure)
 }

--- a/src/test/kotlin/io/github/nomisrev/kafka/receiver/RebalanceRacingCommitSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/kafka/receiver/RebalanceRacingCommitSpec.kt
@@ -7,6 +7,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -22,6 +23,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.MockConsumer
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
@@ -46,7 +48,7 @@ class RebalanceRacingCommitSpec {
 
   @Test
   fun `a commit racing a rebalance is retried instead of failing the receive flow`() = runBlocking {
-    val consumer = failingTheFirstCommitWith(RebalanceInProgressException("commit raced the rebalance"))
+    val consumer = failingCommitsWith(RebalanceInProgressException("commit raced the rebalance"))
     val collecting = collect(consumer)
 
     try {
@@ -65,7 +67,7 @@ class RebalanceRacingCommitSpec {
 
   @Test
   fun `a commit the broker asks to retry is still retried`() = runBlocking {
-    val consumer = failingTheFirstCommitWith(RetriableCommitFailedException("try again"))
+    val consumer = failingCommitsWith(RetriableCommitFailedException("try again"))
     val collecting = collect(consumer)
 
     try {
@@ -83,9 +85,32 @@ class RebalanceRacingCommitSpec {
   }
 
   @Test
+  fun `a commit that keeps racing rebalances gives up after maxCommitAttempts`() = runBlocking {
+    val race = RebalanceInProgressException("commit raced the rebalance")
+    val consumer = failingCommitsWith(race, times = Int.MAX_VALUE)
+    val collecting = collect(consumer, maxCommitAttempts = 3)
+
+    try {
+      /* Retrying is right for as long as the rebalance can still complete, but it has to end:
+       * without a bound a consumer group that never settles keeps a subscription retrying forever
+       * instead of surfacing the failure. */
+      val failure = withTimeoutOrNull(10.seconds) { collecting.flowFailure.await() }
+      assertNotNull(
+        failure,
+        "the receive flow must fail once the attempts are used up, " +
+          "but it was still retrying after ${consumer.attempts} commits"
+      )
+      assertEquals(race::class, failure::class)
+      assertEquals(3, consumer.attempts, "the commit must be attempted exactly maxCommitAttempts times")
+    } finally {
+      collecting.close()
+    }
+  }
+
+  @Test
   fun `a commit failure that will not resolve on its own still fails the receive flow`() = runBlocking {
     val fatal = TopicAuthorizationException("not allowed to commit")
-    val consumer = failingTheFirstCommitWith(fatal)
+    val consumer = failingCommitsWith(fatal)
     val collecting = collect(consumer)
 
     try {
@@ -108,20 +133,21 @@ class RebalanceRacingCommitSpec {
 private const val TOPIC = "commit-race-topic"
 private val PARTITION = TopicPartition(TOPIC, 0)
 
-private fun settings(): ReceiverSettings<String, String> =
+private fun settings(maxCommitAttempts: Int = 100): ReceiverSettings<String, String> =
   ReceiverSettings(
     bootstrapServers = "unused:9092",
     keyDeserializer = StringDeserializer(),
     valueDeserializer = StringDeserializer(),
     groupId = "commit-race-group",
     commitStrategy = CommitStrategy.BySize(1),
-    commitRetryInterval = 50.milliseconds,
+    commitRetryInterval = 20.milliseconds,
+    maxCommitAttempts = maxCommitAttempts,
     closeTimeout = 5.seconds,
   )
 
-/** Fails the first commit with [error], and lets every commit after it succeed. */
-private fun failingTheFirstCommitWith(error: Exception): CommitFailingConsumer =
-  CommitFailingConsumer(error).apply {
+/** Fails the first [times] commits with [error], and lets every commit after them succeed. */
+private fun failingCommitsWith(error: Exception, times: Int = 1): CommitFailingConsumer =
+  CommitFailingConsumer(error, times).apply {
     updateBeginningOffsets(mapOf(PARTITION to 0L))
     schedulePollTask {
       rebalance(listOf(PARTITION))
@@ -129,10 +155,11 @@ private fun failingTheFirstCommitWith(error: Exception): CommitFailingConsumer =
     }
   }
 
-private class CommitFailingConsumer(private val error: Exception) :
+private class CommitFailingConsumer(private val error: Exception, private val times: Int) :
   MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
 
-  private val attempts = AtomicInteger(0)
+  private val attempted = AtomicInteger(0)
+  val attempts: Int get() = attempted.get()
   val successfulCommits = CopyOnWriteArrayList<Map<TopicPartition, OffsetAndMetadata>>()
 
   override fun commitAsync(
@@ -140,7 +167,7 @@ private class CommitFailingConsumer(private val error: Exception) :
     callback: OffsetCommitCallback?,
   ) {
     requireNotNull(callback) { "the event loop always commits with a callback" }
-    if (attempts.incrementAndGet() == 1) callback.onComplete(offsets, error)
+    if (attempted.incrementAndGet() <= times) callback.onComplete(offsets, error)
     else {
       successfulCommits += offsets.toMap()
       callback.onComplete(offsets, null)
@@ -161,7 +188,7 @@ private class Collecting(
   }
 }
 
-private fun collect(consumer: MockConsumer<String, String>): Collecting {
+private fun collect(consumer: MockConsumer<String, String>, maxCommitAttempts: Int = 100): Collecting {
   /* The event loop asserts that it runs on a thread named like the library's own dispatcher. */
   val dispatcher = Executors.newSingleThreadExecutor { runnable ->
     Thread(runnable, "kotlin-kafka-commit-race-group")
@@ -172,7 +199,7 @@ private fun collect(consumer: MockConsumer<String, String>): Collecting {
   val job = scope.launch {
     val loop = EventLoop(
       topicNames = setOf(TOPIC),
-      settings = settings(),
+      settings = settings(maxCommitAttempts),
       consumer = consumer,
       scope = scope,
       outerContext = currentCoroutineContext(),

--- a/src/test/kotlin/io/github/nomisrev/kafka/receiver/RebalanceRacingCommitSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/kafka/receiver/RebalanceRacingCommitSpec.kt
@@ -1,0 +1,97 @@
+package io.github.nomisrev.kafka.receiver
+
+import io.github.nomisRev.kafka.receiver.CommitStrategy
+import io.github.nomisRev.kafka.receiver.ReceiverSettings
+import io.github.nomisRev.kafka.receiver.internals.EventLoop
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.coroutineContext
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.MockConsumer
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.clients.consumer.OffsetCommitCallback
+import org.apache.kafka.clients.consumer.OffsetResetStrategy
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.RebalanceInProgressException
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.junit.jupiter.api.Test
+
+class RebalanceRacingCommitSpec {
+
+  @Test
+  fun `a commit racing a rebalance is retried instead of failing the receive flow`() = runBlocking {
+    val topic = "commit-race-topic"
+    val partition = TopicPartition(topic, 0)
+    val commitAttempts = AtomicInteger(0)
+    val successfulCommits = CopyOnWriteArrayList<Map<TopicPartition, OffsetAndMetadata>>()
+
+    // the first commit races a rebalance, every following commit succeeds
+    val consumer = object : MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
+      override fun commitAsync(
+        offsets: MutableMap<TopicPartition, OffsetAndMetadata>,
+        callback: OffsetCommitCallback?,
+      ) {
+        if (commitAttempts.incrementAndGet() == 1) {
+          callback?.onComplete(offsets, RebalanceInProgressException("commit raced the rebalance"))
+        } else {
+          successfulCommits.add(offsets.toMap())
+          callback?.onComplete(offsets, null)
+        }
+      }
+    }
+    consumer.updateBeginningOffsets(mapOf(partition to 0L))
+    consumer.schedulePollTask {
+      consumer.rebalance(listOf(partition))
+      consumer.addRecord(ConsumerRecord(topic, 0, 0L, "key", "value"))
+    }
+
+    val settings = ReceiverSettings(
+      bootstrapServers = "unused:9092",
+      keyDeserializer = StringDeserializer(),
+      valueDeserializer = StringDeserializer(),
+      groupId = "commit-race-group",
+      commitStrategy = CommitStrategy.BySize(1),
+    )
+
+    // the event loop asserts that it runs on a thread named like the library's own dispatcher
+    val dispatcher = Executors.newSingleThreadExecutor { r ->
+      Thread(r, "kotlin-kafka-commit-race-group")
+    }.asCoroutineDispatcher()
+    val job = Job()
+    val scope = CoroutineScope(job + dispatcher)
+    try {
+      val loop = EventLoop(setOf(topic), settings, consumer, scope, coroutineContext)
+      val firstRecord = CompletableDeferred<ConsumerRecord<String, String>>()
+      val collector = launch {
+        loop.receive().collect { records ->
+          records.forEach { record -> firstRecord.complete(record) }
+        }
+      }
+
+      withTimeout(30.seconds) {
+        loop.offsetFromRecord(firstRecord.await()).acknowledge()
+        while (successfulCommits.isEmpty()) delay(50)
+      }
+      collector.cancelAndJoin()
+
+      // without retrying the racing commit, the collector would have failed with
+      // RebalanceInProgressException before any successful commit could happen
+      assertEquals(1L, successfulCommits.first()[partition]?.offset())
+    } finally {
+      job.cancelAndJoin()
+      dispatcher.close()
+    }
+  }
+}

--- a/src/test/kotlin/io/github/nomisrev/kafka/receiver/RebalanceRacingCommitSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/kafka/receiver/RebalanceRacingCommitSpec.kt
@@ -49,13 +49,13 @@ class RebalanceRacingCommitSpec {
   @Test
   fun `a commit racing a rebalance is retried instead of failing the receive flow`() = runBlocking {
     val consumer = failingCommitsWith(RebalanceInProgressException("commit raced the rebalance"))
-    val collecting = collect(consumer)
+    val collecting = collectCommitRace(consumer)
 
     try {
       withTimeout(30.seconds) {
         while (consumer.successfulCommits.isEmpty()) delay(20)
       }
-      assertEquals(1L, consumer.successfulCommits.first()[PARTITION]?.offset())
+      assertEquals(1L, consumer.successfulCommits.first()[COMMIT_RACE_PARTITION]?.offset())
       assertNull(
         collecting.flowFailure.takeIf { it.isCompleted }?.await(),
         "a commit that raced a rebalance must not fail the receive flow"
@@ -68,13 +68,13 @@ class RebalanceRacingCommitSpec {
   @Test
   fun `a commit the broker asks to retry is still retried`() = runBlocking {
     val consumer = failingCommitsWith(RetriableCommitFailedException("try again"))
-    val collecting = collect(consumer)
+    val collecting = collectCommitRace(consumer)
 
     try {
       withTimeout(30.seconds) {
         while (consumer.successfulCommits.isEmpty()) delay(20)
       }
-      assertEquals(1L, consumer.successfulCommits.first()[PARTITION]?.offset())
+      assertEquals(1L, consumer.successfulCommits.first()[COMMIT_RACE_PARTITION]?.offset())
       assertNull(
         collecting.flowFailure.takeIf { it.isCompleted }?.await(),
         "the retry the broker asked for must not fail the receive flow"
@@ -88,7 +88,7 @@ class RebalanceRacingCommitSpec {
   fun `a commit that keeps racing rebalances gives up after maxCommitAttempts`() = runBlocking {
     val race = RebalanceInProgressException("commit raced the rebalance")
     val consumer = failingCommitsWith(race, times = Int.MAX_VALUE)
-    val collecting = collect(consumer, maxCommitAttempts = 3)
+    val collecting = collectCommitRace(consumer, maxCommitAttempts = 3)
 
     try {
       /* Retrying is right for as long as the rebalance can still complete, but it has to end:
@@ -111,7 +111,7 @@ class RebalanceRacingCommitSpec {
   fun `a commit failure that will not resolve on its own still fails the receive flow`() = runBlocking {
     val fatal = TopicAuthorizationException("not allowed to commit")
     val consumer = failingCommitsWith(fatal)
-    val collecting = collect(consumer)
+    val collecting = collectCommitRace(consumer)
 
     try {
       val failure = withTimeout(30.seconds) { collecting.flowFailure.await() }
@@ -130,10 +130,10 @@ class RebalanceRacingCommitSpec {
   }
 }
 
-private const val TOPIC = "commit-race-topic"
-private val PARTITION = TopicPartition(TOPIC, 0)
+private const val COMMIT_RACE_TOPIC = "commit-race-topic"
+private val COMMIT_RACE_PARTITION = TopicPartition(COMMIT_RACE_TOPIC, 0)
 
-private fun settings(maxCommitAttempts: Int = 100): ReceiverSettings<String, String> =
+private fun commitRaceSettings(maxCommitAttempts: Int = 100): ReceiverSettings<String, String> =
   ReceiverSettings(
     bootstrapServers = "unused:9092",
     keyDeserializer = StringDeserializer(),
@@ -148,10 +148,10 @@ private fun settings(maxCommitAttempts: Int = 100): ReceiverSettings<String, Str
 /** Fails the first [times] commits with [error], and lets every commit after them succeed. */
 private fun failingCommitsWith(error: Exception, times: Int = 1): CommitFailingConsumer =
   CommitFailingConsumer(error, times).apply {
-    updateBeginningOffsets(mapOf(PARTITION to 0L))
+    updateBeginningOffsets(mapOf(COMMIT_RACE_PARTITION to 0L))
     schedulePollTask {
-      rebalance(listOf(PARTITION))
-      addRecord(ConsumerRecord(TOPIC, PARTITION.partition(), 0L, "key", "value"))
+      rebalance(listOf(COMMIT_RACE_PARTITION))
+      addRecord(ConsumerRecord(COMMIT_RACE_TOPIC, COMMIT_RACE_PARTITION.partition(), 0L, "key", "value"))
     }
   }
 
@@ -175,7 +175,7 @@ private class CommitFailingConsumer(private val error: Exception, private val ti
   }
 }
 
-private class Collecting(
+private class CommitRaceCollecting(
   private val job: Job,
   private val scope: CoroutineScope,
   private val dispatcher: ExecutorCoroutineDispatcher,
@@ -188,7 +188,10 @@ private class Collecting(
   }
 }
 
-private fun collect(consumer: MockConsumer<String, String>, maxCommitAttempts: Int = 100): Collecting {
+private fun collectCommitRace(
+  consumer: MockConsumer<String, String>,
+  maxCommitAttempts: Int = 100,
+): CommitRaceCollecting {
   /* The event loop asserts that it runs on a thread named like the library's own dispatcher. */
   val dispatcher = Executors.newSingleThreadExecutor { runnable ->
     Thread(runnable, "kotlin-kafka-commit-race-group")
@@ -198,8 +201,8 @@ private fun collect(consumer: MockConsumer<String, String>, maxCommitAttempts: I
 
   val job = scope.launch {
     val loop = EventLoop(
-      topicNames = setOf(TOPIC),
-      settings = settings(maxCommitAttempts),
+      topicNames = setOf(COMMIT_RACE_TOPIC),
+      settings = commitRaceSettings(maxCommitAttempts),
       consumer = consumer,
       scope = scope,
       outerContext = currentCoroutineContext(),
@@ -211,5 +214,5 @@ private fun collect(consumer: MockConsumer<String, String>, maxCommitAttempts: I
       }
   }
 
-  return Collecting(job, scope, dispatcher, flowFailure)
+  return CommitRaceCollecting(job, scope, dispatcher, flowFailure)
 }


### PR DESCRIPTION
When an async offset commit races a consumer-group rebalance, the broker answers with `RebalanceInProgressException`. The default `isRetryableCommit` only recognizes `RetriableCommitFailedException`, so `commitFailure` closes the record channel and fails the whole receive flow. Rebalances are routine whenever a group has more than one member, so with a time-based commit strategy this is just a matter of time - in our production setup one racing commit killed the consumer, the resulting restart made a member leave, which triggered the next rebalance for the remaining replicas: a self-sustaining restart cascade. reactor-kafka, where the commit-batch logic originates, re-enqueues these commits.

This PR adds `RebalanceInProgressException` to the retryable classification (extracted into a documented function) and a `MockConsumer`-based regression test that reproduces the race deterministically. An alternative would be exposing `isRetryableCommit` via `ReceiverSettings` - happy to rework in that direction if preferred.

Unrelated observation while reading `commitFailure`: the condition `!isRetryableCommit(e) && consecutiveCommitFailures.incrementAndGet() < maxCommitAttempts` sends a non-retryable failure *below* `maxCommitAttempts` into the fatal branch and one *above* into the retry branch - is that inverted? Left untouched here to keep the scope small.