### PR TITLE
Fix ConcurrentModificationException when a rebalance revokes user-paused partitions

### DIFF
--- a/src/main/kotlin/io/github/nomisRev/kafka/receiver/internals/EventLoop.kt
+++ b/src/main/kotlin/io/github/nomisRev/kafka/receiver/internals/EventLoop.kt
@@ -250,13 +250,13 @@ internal class EventLoop<K, V>(
 
     /* It is necessary to re-pause any user-paused partitions that are re-assigned after the rebalance.
      * Also remove any revoked partitions that the user paused from the userPaused collection. */
-    private fun partitionsToRepause(partitions: Collection<TopicPartition>): List<TopicPartition> =
-      buildList {
-        pausedPartitionsByUser.forEach { tp ->
-          if (partitions.contains(tp)) add(tp)
-          else pausedPartitionsByUser.remove(tp)
-        }
-      }
+    private fun partitionsToRepause(partitions: Collection<TopicPartition>): List<TopicPartition> {
+      /* Dropping the revoked ones with `retainAll` rather than removing them while iterating:
+       * the loop this replaces removed from the very set it was walking, which throws a
+       * ConcurrentModificationException as soon as more than one partition is revoked. */
+      pausedPartitionsByUser.retainAll(partitions.toSet())
+      return pausedPartitionsByUser.toList()
+    }
   }
 
   @ConsumerThread

--- a/src/test/kotlin/io/github/nomisrev/kafka/receiver/RebalanceDuringBackPressureSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/kafka/receiver/RebalanceDuringBackPressureSpec.kt
@@ -1,0 +1,156 @@
+package io.github.nomisrev.kafka.receiver
+
+import io.github.nomisRev.kafka.receiver.CommitStrategy
+import io.github.nomisRev.kafka.receiver.ReceiverSettings
+import io.github.nomisRev.kafka.receiver.internals.EventLoop
+import java.time.Duration as JavaDuration
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.clients.consumer.MockConsumer
+import org.apache.kafka.clients.consumer.OffsetResetStrategy
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.junit.jupiter.api.Test
+
+/**
+ * The event loop remembers the partitions the user had paused when it starts back pressuring, so
+ * that it can leave them paused after a rebalance. A rebalance that takes those partitions away
+ * has to survive that bookkeeping.
+ */
+class RebalanceDuringBackPressureSpec {
+
+  @Test
+  fun `a rebalance that drops user paused partitions does not break the subscription`() = runBlocking {
+    val rebalanceNow = AtomicBoolean(false)
+    val backPressured = CompletableDeferred<Unit>()
+    val secondBatchPolled = CompletableDeferred<Unit>()
+    val nonEmptyPolls = AtomicInteger(0)
+    val listener = CompletableDeferred<ConsumerRebalanceListener>()
+    val rebalanceHappened = CompletableDeferred<Unit>()
+    val releaseCollector = CompletableDeferred<Unit>()
+
+    val consumer = object : MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
+      override fun subscribe(topics: MutableCollection<String>, callback: ConsumerRebalanceListener) {
+        listener.complete(callback)
+        super.subscribe(topics, callback)
+      }
+
+      /* A real consumer runs the rebalance callbacks from inside poll; MockConsumer does not
+       * (it has a "TODO: Rebalance callbacks"), so the probe does it here instead. */
+      override fun poll(timeout: JavaDuration): ConsumerRecords<String, String> {
+        if (rebalanceNow.compareAndSet(true, false)) {
+          try {
+            listener.getCompleted().onPartitionsAssigned(mutableListOf(PARTITIONS[0]))
+          } finally {
+            rebalanceHappened.complete(Unit)
+          }
+        }
+        return super.poll(timeout).also {
+          if (!it.isEmpty && nonEmptyPolls.incrementAndGet() == 2) secondBatchPolled.complete(Unit)
+        }
+      }
+
+      override fun pause(partitions: MutableCollection<TopicPartition>) {
+        super.pause(partitions)
+        /* Only the loop's own "pause everything" completes this, not the probe's user pause. */
+        if (partitions.size == PARTITIONS.size) backPressured.complete(Unit)
+      }
+    }
+
+    consumer.updateBeginningOffsets(PARTITIONS.associateWith { 0L })
+    var record = 0L
+    repeat(2) {
+      consumer.schedulePollTask {
+        if (record == 0L) {
+          consumer.rebalance(PARTITIONS)
+          /* Two partitions the user paused: the loop remembers them when it back pressures. */
+          consumer.pause(PARTITIONS.drop(1).toMutableList())
+        }
+        consumer.addRecord(ConsumerRecord(TOPIC, 0, record, "key-$record", "value-$record"))
+        record++
+      }
+    }
+
+    val dispatcher = Executors.newSingleThreadExecutor { r -> Thread(r, "kotlin-kafka-probe-group") }
+      .asCoroutineDispatcher()
+    val scope = CoroutineScope(Job() + dispatcher)
+    val collectorDispatcher = Executors.newSingleThreadExecutor { r -> Thread(r, "probe-collector") }
+      .asCoroutineDispatcher()
+    val collectorScope = CoroutineScope(Job() + collectorDispatcher)
+    val flowFailure = CompletableDeferred<Throwable>()
+    val acknowledge = CompletableDeferred<Unit>()
+    val batches = AtomicInteger(0)
+
+    val collecting = collectorScope.launch {
+      val loop = EventLoop(
+        topicNames = setOf(TOPIC),
+        settings = settings(),
+        consumer = consumer,
+        scope = scope,
+        outerContext = currentCoroutineContext(),
+      )
+      loop.receive()
+        .catch { e -> flowFailure.complete(e) }
+        .collect { records ->
+          if (batches.incrementAndGet() == 1) {
+            acknowledge.await()
+            records.forEach { r -> loop.offsetFromRecord(r).acknowledge() }
+            releaseCollector.await()
+          }
+        }
+    }
+
+    try {
+      withTimeout(30.seconds) { secondBatchPolled.await() }
+      acknowledge.complete(Unit)
+      withTimeout(30.seconds) { backPressured.await() }
+
+      rebalanceNow.set(true)
+      withTimeout(30.seconds) { rebalanceHappened.await() }
+      releaseCollector.complete(Unit)
+      val failure = withTimeoutOrNull(10.seconds) { flowFailure.await() }
+
+      assertNull(
+        failure,
+        "the rebalance must not fail the receive flow, but it failed with " +
+          "${failure?.let { "${it::class.simpleName}: ${it.message}" }}"
+      )
+    } finally {
+      collecting.cancelAndJoin()
+      collectorScope.coroutineContext[Job]?.cancelAndJoin()
+      scope.coroutineContext[Job]?.cancelAndJoin()
+      dispatcher.close()
+      collectorDispatcher.close()
+    }
+  }
+}
+
+private const val TOPIC = "probe-topic"
+private val PARTITIONS = listOf(0, 1, 2).map { TopicPartition(TOPIC, it) }
+
+private fun settings(): ReceiverSettings<String, String> =
+  ReceiverSettings(
+    bootstrapServers = "unused:9092",
+    keyDeserializer = StringDeserializer(),
+    valueDeserializer = StringDeserializer(),
+    groupId = "probe-group",
+    commitStrategy = CommitStrategy.BySize(1),
+    closeTimeout = 5.seconds,
+  )

--- a/src/test/kotlin/io/github/nomisrev/kafka/receiver/RebalanceDuringBackPressureSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/kafka/receiver/RebalanceDuringBackPressureSpec.kt
@@ -57,7 +57,7 @@ class RebalanceDuringBackPressureSpec {
       override fun poll(timeout: JavaDuration): ConsumerRecords<String, String> {
         if (rebalanceNow.compareAndSet(true, false)) {
           try {
-            listener.getCompleted().onPartitionsAssigned(mutableListOf(PARTITIONS[0]))
+            listener.getCompleted().onPartitionsAssigned(mutableListOf(REPAUSE_PARTITIONS[0]))
           } finally {
             rebalanceHappened.complete(Unit)
           }
@@ -70,20 +70,20 @@ class RebalanceDuringBackPressureSpec {
       override fun pause(partitions: MutableCollection<TopicPartition>) {
         super.pause(partitions)
         /* Only the loop's own "pause everything" completes this, not the probe's user pause. */
-        if (partitions.size == PARTITIONS.size) backPressured.complete(Unit)
+        if (partitions.size == REPAUSE_PARTITIONS.size) backPressured.complete(Unit)
       }
     }
 
-    consumer.updateBeginningOffsets(PARTITIONS.associateWith { 0L })
+    consumer.updateBeginningOffsets(REPAUSE_PARTITIONS.associateWith { 0L })
     var record = 0L
     repeat(2) {
       consumer.schedulePollTask {
         if (record == 0L) {
-          consumer.rebalance(PARTITIONS)
+          consumer.rebalance(REPAUSE_PARTITIONS)
           /* Two partitions the user paused: the loop remembers them when it back pressures. */
-          consumer.pause(PARTITIONS.drop(1).toMutableList())
+          consumer.pause(REPAUSE_PARTITIONS.drop(1).toMutableList())
         }
-        consumer.addRecord(ConsumerRecord(TOPIC, 0, record, "key-$record", "value-$record"))
+        consumer.addRecord(ConsumerRecord(REPAUSE_TOPIC, 0, record, "key-$record", "value-$record"))
         record++
       }
     }
@@ -100,8 +100,8 @@ class RebalanceDuringBackPressureSpec {
 
     val collecting = collectorScope.launch {
       val loop = EventLoop(
-        topicNames = setOf(TOPIC),
-        settings = settings(),
+        topicNames = setOf(REPAUSE_TOPIC),
+        settings = repauseSettings(),
         consumer = consumer,
         scope = scope,
         outerContext = currentCoroutineContext(),
@@ -142,10 +142,10 @@ class RebalanceDuringBackPressureSpec {
   }
 }
 
-private const val TOPIC = "probe-topic"
-private val PARTITIONS = listOf(0, 1, 2).map { TopicPartition(TOPIC, it) }
+private const val REPAUSE_TOPIC = "probe-topic"
+private val REPAUSE_PARTITIONS = listOf(0, 1, 2).map { TopicPartition(REPAUSE_TOPIC, it) }
 
-private fun settings(): ReceiverSettings<String, String> =
+private fun repauseSettings(): ReceiverSettings<String, String> =
   ReceiverSettings(
     bootstrapServers = "unused:9092",
     keyDeserializer = StringDeserializer(),


### PR DESCRIPTION
## The problem

`partitionsToRepause` removes from the set it is iterating:

https://github.com/nomisRev/kotlin-kafka/blob/0.4.1/src/main/kotlin/io/github/nomisRev/kafka/receiver/internals/EventLoop.kt#L253-L259

```kotlin
pausedPartitionsByUser.forEach { tp ->
  if (partitions.contains(tp)) add(tp)
  else pausedPartitionsByUser.remove(tp)   // <- same HashSet
}
```

`pausedPartitionsByUser` is a `HashSet`, so a second removal throws `ConcurrentModificationException`. With exactly one revoked partition it happens to survive — `hasNext()` returns false before the iterator checks `modCount` — which is presumably why it has gone unnoticed.

It is not a harmless one either. The call sits in `RebalanceListener.onPartitionsAssigned`, which a real consumer invokes from inside `poll()`. There it lands in the `catch (e: Exception)` around the poll body, which calls `closeChannel(e)` — so **the subscription dies with a `ConcurrentModificationException`**.

## When it is reachable

`pausedPartitionsByUser` is only ever filled in one place, and that place is back pressure:

```kotlin
} else if (pauseAndWakeupIfNeeded()) {
  pausedPartitionsByUser.addAll(consumer.paused())
  consumer.pause(consumer.assignment())
```

So the trigger is: the collector falls behind, the loop pauses the consumer and remembers what the user had already paused, and then a rebalance revokes at least two of those partitions. A group that is rebalancing while its members are behind is exactly the situation this bookkeeping exists for, so the failure lands on a consumer that is already under strain.

## The change

`retainAll` does the same thing — keep what is still assigned, drop what is not — without mutating during iteration.

## Test

`RebalanceDuringBackPressureSpec` drives the loop into back pressure with two user-paused partitions and then delivers a rebalance that revokes both. On `main` it fails with

```
the rebalance must not fail the receive flow, but it failed with ConcurrentModificationException: null
```

and passes with the fix.

One note on the test: `MockConsumer.rebalance` does not invoke the rebalance callbacks (there is a `// TODO: Rebalance callbacks` in the Kafka code), so the spec captures the listener passed to `subscribe` and invokes it from inside its own `poll` override. That keeps the callback where a real consumer runs it — inside `poll` — which is what makes the exception reach `closeChannel` rather than the caller.

Independent of #215, #216 and #218; branched off `main`.
