### PR TITLE
Do not commit partitions the consumer has already lost

### DIFF
--- a/src/main/kotlin/io/github/nomisRev/kafka/receiver/internals/CommittableBatch.kt
+++ b/src/main/kotlin/io/github/nomisRev/kafka/receiver/internals/CommittableBatch.kt
@@ -77,6 +77,27 @@ internal class CommittableBatch {
     })
   }
   
+  /**
+   * Drops everything held for partitions the consumer has *lost*, so that no later commit carries them.
+   *
+   * [onPartitionsRevoked] alone is not enough: it clears only the out-of-order bookkeeping, while the offsets a
+   * commit is actually built from live in [consumedOffsets]. A revoked partition is committed on the way out and
+   * emptied by that commit; a lost one is never committed, so it has to be dropped here or the next commit would
+   * still carry it.
+   */
+  // Called from ConsumerRebalanceListener, thus from our single threaded kafka dispatcher
+  @Synchronized
+  fun onPartitionsLost(lost: Collection<TopicPartition>) {
+    onPartitionsRevoked(lost)
+    lost.forEach(Consumer { part: TopicPartition ->
+      consumedOffsets.remove(part)
+      latestOffsets.remove(part)
+    })
+    /* batchSize counts updates rather than partitions, so what these offsets contributed to it cannot be
+     * subtracted. Left too high it can only bring the next commit of the remaining partitions forward, and a
+     * commit that ends up with no offsets at all completes without a broker round trip. */
+  }
+  
   // Called from suspend poll, and getAndClearOffsets
   @Synchronized
   fun deferredCount(): Int {

--- a/src/main/kotlin/io/github/nomisRev/kafka/receiver/internals/EventLoop.kt
+++ b/src/main/kotlin/io/github/nomisRev/kafka/receiver/internals/EventLoop.kt
@@ -248,6 +248,27 @@ internal class EventLoop<K, V>(
       commitBatch.onPartitionsRevoked(partitions)
     }
 
+    /**
+     * Kafka calls this instead of [onPartitionsRevoked] once the member has already left the group -
+     * after a session timeout, or when the coordinator fenced it.
+     *
+     * The interface's default implementation forwards here to [onPartitionsRevoked], which commits. That commit
+     * cannot succeed: the member no longer owns these partitions, so the broker answers with
+     * [org.apache.kafka.clients.consumer.CommitFailedException], which is not a
+     * [org.apache.kafka.clients.consumer.RetriableCommitFailedException] and therefore ends the receive flow.
+     * Losing the group is recoverable - the consumer rejoins - but the commit attempt turns it into a terminal
+     * failure of the whole subscription.
+     *
+     * So the offsets are dropped rather than committed: they belong to a generation that is gone, and their
+     * records are redelivered to whoever holds the partitions now.
+     */
+    @ConsumerThread
+    override fun onPartitionsLost(partitions: Collection<TopicPartition>) {
+      checkConsumerThread("RebalanceListener.onPartitionsLost")
+      logger.debug("onPartitionsLost {}", partitions)
+      commitBatch.onPartitionsRevoked(partitions)
+    }
+
     /* It is necessary to re-pause any user-paused partitions that are re-assigned after the rebalance.
      * Also remove any revoked partitions that the user paused from the userPaused collection. */
     private fun partitionsToRepause(partitions: Collection<TopicPartition>): List<TopicPartition> =

--- a/src/main/kotlin/io/github/nomisRev/kafka/receiver/internals/EventLoop.kt
+++ b/src/main/kotlin/io/github/nomisRev/kafka/receiver/internals/EventLoop.kt
@@ -266,7 +266,7 @@ internal class EventLoop<K, V>(
     override fun onPartitionsLost(partitions: Collection<TopicPartition>) {
       checkConsumerThread("RebalanceListener.onPartitionsLost")
       logger.debug("onPartitionsLost {}", partitions)
-      commitBatch.onPartitionsRevoked(partitions)
+      commitBatch.onPartitionsLost(partitions)
     }
 
     /* It is necessary to re-pause any user-paused partitions that are re-assigned after the rebalance.

--- a/src/test/kotlin/io/github/nomisrev/kafka/receiver/PartitionsLostSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/kafka/receiver/PartitionsLostSpec.kt
@@ -1,0 +1,184 @@
+package io.github.nomisrev.kafka.receiver
+
+import io.github.nomisRev.kafka.receiver.CommitStrategy
+import io.github.nomisRev.kafka.receiver.ReceiverSettings
+import io.github.nomisRev.kafka.receiver.internals.EventLoop
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.MockConsumer
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.clients.consumer.OffsetCommitCallback
+import org.apache.kafka.clients.consumer.OffsetResetStrategy
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.junit.jupiter.api.Test
+
+/**
+ * Partitions that were *lost* - the member already left the group - must not be committed. The broker answers such a
+ * commit with `CommitFailedException`, which is not retryable and would end the receive flow over something the
+ * consumer recovers from by rejoining.
+ */
+class PartitionsLostSpec {
+
+  @Test
+  fun `losing partitions does not commit them`() = runBlocking {
+    val consumer = ListenerCapturingConsumer().seededWithOneRecord()
+    val collecting = collectAcknowledging(consumer)
+
+    try {
+      withTimeout(30.seconds) { consumer.firstRecordAcknowledged.await() }
+
+      consumer.callListenerOnConsumerThread { it.onPartitionsLost(mutableListOf(LOST_PARTITION)) }
+
+      assertEquals(emptyList(), consumer.committedOffsets.toList(), "lost partitions must not be committed")
+      assertNull(
+        collecting.flowFailure.takeIf { it.isCompleted }?.await(),
+        "losing partitions must not end the receive flow"
+      )
+    } finally {
+      collecting.close()
+    }
+  }
+
+  @Test
+  fun `revoking partitions still commits them`() = runBlocking {
+    val consumer = ListenerCapturingConsumer().seededWithOneRecord()
+    val collecting = collectAcknowledging(consumer)
+
+    try {
+      withTimeout(30.seconds) { consumer.firstRecordAcknowledged.await() }
+
+      consumer.callListenerOnConsumerThread { it.onPartitionsRevoked(mutableListOf(LOST_PARTITION)) }
+
+      withTimeout(30.seconds) {
+        while (consumer.committedOffsets.isEmpty()) delay(20)
+      }
+      assertEquals(1L, consumer.committedOffsets.first()[LOST_PARTITION]?.offset())
+    } finally {
+      collecting.close()
+    }
+  }
+}
+
+private const val LOST_TOPIC = "partitions-lost-topic"
+private val LOST_PARTITION = TopicPartition(LOST_TOPIC, 0)
+private const val LOST_RECEIVER_THREAD = "kotlin-kafka-partitions-lost-group"
+
+private fun lostSettings(): ReceiverSettings<String, String> =
+  ReceiverSettings(
+    bootstrapServers = "unused:9092",
+    keyDeserializer = StringDeserializer(),
+    valueDeserializer = StringDeserializer(),
+    groupId = "partitions-lost-group",
+    // only an explicit rebalance callback should trigger a commit in these tests
+    commitStrategy = CommitStrategy.ByTime(1.seconds),
+    closeTimeout = 5.seconds,
+  )
+
+private open class ListenerCapturingConsumer : MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
+  private val listener = CompletableDeferred<ConsumerRebalanceListener>()
+  private val callListener = CompletableDeferred<(ConsumerRebalanceListener) -> Unit>()
+  private val invoking = AtomicBoolean(false)
+  private val listenerReturned = CompletableDeferred<Unit>()
+
+  val committedOffsets = CopyOnWriteArrayList<Map<TopicPartition, OffsetAndMetadata>>()
+  val firstRecordAcknowledged = CompletableDeferred<Unit>()
+
+  override fun subscribe(topics: MutableCollection<String>, callback: ConsumerRebalanceListener) {
+    listener.complete(callback)
+    super.subscribe(topics, callback)
+  }
+
+  override fun commitAsync(
+    offsets: MutableMap<TopicPartition, OffsetAndMetadata>,
+    callback: OffsetCommitCallback?,
+  ) {
+    requireNotNull(callback) { "the event loop always commits with a callback" }
+    committedOffsets += offsets.toMap()
+    callback.onComplete(offsets, null)
+  }
+
+  /* The event loop asserts it runs on its own thread, so the callback is invoked from inside a poll. */
+  override fun poll(timeout: java.time.Duration): org.apache.kafka.clients.consumer.ConsumerRecords<String, String> {
+    if (callListener.isCompleted && invoking.compareAndSet(false, true)) {
+      @Suppress("OPT_IN_USAGE")
+      try {
+        callListener.getCompleted()(listener.getCompleted())
+      } finally {
+        // only now has the callback run to completion, so only now may the test assert on its effects
+        listenerReturned.complete(Unit)
+      }
+    }
+    return super.poll(timeout)
+  }
+
+  suspend fun callListenerOnConsumerThread(action: (ConsumerRebalanceListener) -> Unit) {
+    listener.await()
+    callListener.complete(action)
+    withTimeout(10.seconds) { listenerReturned.await() }
+  }
+}
+
+private fun <A : MockConsumer<String, String>> A.seededWithOneRecord(): A = apply {
+  updateBeginningOffsets(mapOf(LOST_PARTITION to 0L))
+  schedulePollTask {
+    rebalance(listOf(LOST_PARTITION))
+    addRecord(ConsumerRecord(LOST_TOPIC, 0, 0L, "key", "value"))
+  }
+}
+
+private class LostCollecting(
+  private val job: Job,
+  private val scope: CoroutineScope,
+  private val dispatcher: ExecutorCoroutineDispatcher,
+  val flowFailure: CompletableDeferred<Throwable>,
+) {
+  suspend fun close() {
+    job.cancelAndJoin()
+    scope.coroutineContext[Job]?.cancelAndJoin()
+    dispatcher.close()
+  }
+}
+
+private fun collectAcknowledging(consumer: ListenerCapturingConsumer): LostCollecting {
+  val dispatcher =
+    Executors.newSingleThreadExecutor { runnable -> Thread(runnable, LOST_RECEIVER_THREAD) }.asCoroutineDispatcher()
+  val scope = CoroutineScope(Job() + dispatcher)
+  val flowFailure = CompletableDeferred<Throwable>()
+
+  val job = scope.launch {
+    val loop = EventLoop(
+      topicNames = setOf(LOST_TOPIC),
+      settings = lostSettings(),
+      consumer = consumer,
+      scope = scope,
+      outerContext = currentCoroutineContext(),
+    )
+    loop.receive()
+      .catch { e -> flowFailure.complete(e) }
+      .collect { records ->
+        records.forEach { record -> loop.offsetFromRecord(record).acknowledge() }
+        consumer.firstRecordAcknowledged.complete(Unit)
+      }
+  }
+
+  return LostCollecting(job, scope, dispatcher, flowFailure)
+}

--- a/src/test/kotlin/io/github/nomisrev/kafka/receiver/PartitionsLostSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/kafka/receiver/PartitionsLostSpec.kt
@@ -59,6 +59,34 @@ class PartitionsLostSpec {
   }
 
   @Test
+  fun `losing partitions does not commit them on a later tick either`() = runBlocking {
+    val consumer = ListenerCapturingConsumer().seededWithOneRecord()
+    val collecting = collectAcknowledging(consumer)
+
+    try {
+      withTimeout(30.seconds) { consumer.firstRecordAcknowledged.await() }
+
+      consumer.callListenerOnConsumerThread { it.onPartitionsLost(mutableListOf(LOST_PARTITION)) }
+
+      /* Not committing *during* the callback is only half of it: the acknowledged offsets stay in the batch
+       * until they are dropped, and the periodic commit of `ByTime` is what would send them afterwards. */
+      delay(COMMIT_INTERVAL * 3)
+
+      assertEquals(
+        emptyList(),
+        consumer.committedOffsets.toList(),
+        "a commit after the partitions were lost must not carry them either"
+      )
+      assertNull(
+        collecting.flowFailure.takeIf { it.isCompleted }?.await(),
+        "losing partitions must not end the receive flow"
+      )
+    } finally {
+      collecting.close()
+    }
+  }
+
+  @Test
   fun `revoking partitions still commits them`() = runBlocking {
     val consumer = ListenerCapturingConsumer().seededWithOneRecord()
     val collecting = collectAcknowledging(consumer)
@@ -79,6 +107,7 @@ class PartitionsLostSpec {
 }
 
 private const val LOST_TOPIC = "partitions-lost-topic"
+private val COMMIT_INTERVAL = 1.seconds
 private val LOST_PARTITION = TopicPartition(LOST_TOPIC, 0)
 private const val LOST_RECEIVER_THREAD = "kotlin-kafka-partitions-lost-group"
 
@@ -88,8 +117,7 @@ private fun lostSettings(): ReceiverSettings<String, String> =
     keyDeserializer = StringDeserializer(),
     valueDeserializer = StringDeserializer(),
     groupId = "partitions-lost-group",
-    // only an explicit rebalance callback should trigger a commit in these tests
-    commitStrategy = CommitStrategy.ByTime(1.seconds),
+    commitStrategy = CommitStrategy.ByTime(COMMIT_INTERVAL),
     closeTimeout = 5.seconds,
   )
 


### PR DESCRIPTION
`ConsumerRebalanceListener.onPartitionsLost` is a **default** method that forwards to `onPartitionsRevoked`, and `EventLoop.RebalanceListener` does not override it. So a member that the coordinator has fenced — or that lost the group to a session timeout — runs the revoke path:

```kotlin
private fun partitionsRevoked(partitions: Collection<TopicPartition>) {
    if (!partitions.isEmpty()) {
        if (ackMode != ATMOST_ONCE) runCommitIfRequired(true)   // commits partitions we no longer own
    }
}
```

That commit cannot succeed. The broker answers with `CommitFailedException`:

```
Offset commit cannot be completed since the consumer is not part of an active group
for auto partition assignment; it is likely that the consumer was kicked out of the group.
```

And `CommitFailedException extends KafkaException` while `RetriableCommitFailedException extends RetriableException` — unrelated branches — so `isRetryableCommit` is false, `commitFailure` takes the fatal path and `closeChannel` ends the receive flow.

The net effect is that **losing the group, which a consumer recovers from by rejoining, becomes a terminal failure of the subscription**. The commit attempt is the only reason it is terminal.

## How it shows up

Seen in production, on the equivalent path in reactor-kafka (which has the same gap):

```
ConsumerCoordinator.onJoinPrepare
  -> invokePartitionsLost
    -> ConsumerRebalanceListener.onPartitionsLost      <- interface default
      -> onPartitionsRevoked -> commitAsync -> CommitFailedException
```

A pod that missed two heartbeats lost its subscription permanently and had to be restarted. Tight `session.timeout.ms` makes it likelier, but nothing about it is configuration-specific — any fenced member takes this path.

## The change

`onPartitionsLost` is overridden to drop the batch rather than commit it. The offsets belong to a generation that is gone, and their records are redelivered to whoever holds the partitions now, so there is nothing to preserve.

Dropping means all of it, which is why `CommittableBatch` gets its own `onPartitionsLost`. `onPartitionsRevoked` clears `uncommitted` and `deferred`, and those hold anything at all only on the out-of-order commit path; the offsets a commit is built from live in `consumedOffsets`. A revoked partition is committed on the way out and emptied by that commit, so clearing the rest is enough for it. A lost one is never committed — so leaving `consumedOffsets` alone would only move the failure to the next periodic commit, with the same non-retryable `CommitFailedException` one commit interval later.

## Tests

`PartitionsLostSpec`, on a `MockConsumer`, no broker:

- `losing partitions does not commit them` — fails on `main` (the default forwards to the revoke path and commits), passes with the fix.
- `losing partitions does not commit them on a later tick either` — waits past the `ByTime` commit interval. This is the one that pins the `consumedOffsets` half: with the offsets merely skipped rather than dropped, it fails.
- `revoking partitions still commits them` — passes either way; it guards the change from over-reaching into the ordinary revoke path.

The spec captures the listener the receiver registers in `subscribe` and invokes it from inside `poll`, which is where a real consumer calls it, so the callback runs on the consumer thread the event loop asserts on.

